### PR TITLE
manifest: derp: fix derp in clang gitlab repo

### DIFF
--- a/snippets/derp.xml
+++ b/snippets/derp.xml
@@ -157,7 +157,7 @@
   <project path="packages/services/Telephony" name="packages_services_Telephony" groups="pdk-cw-fs,pdk-fs" remote="derp" />
 
   <!-- Prebuilts -->
-  <project path="prebuilts/clang/host/linux-x86" name="prebuilts_clang_host_linux-x-86" remote="derp-gitlab" revision="12" clone-depth="1" />
+  <project path="prebuilts/clang/host/linux-x86" name="prebuilts-clang-host-linux-x-86" remote="derp-gitlab" revision="12" clone-depth="1" />
 
   <!-- System -->
   <project path="system/apex" name="system_apex" groups="pdk" remote="derp" />


### PR DESCRIPTION

* prebuilts_clang_host_linux-x-86 -> prebuilts-clang-host-linux-x-86
* Fixes
  remote: HTTP Basic: Access denied
  fatal: Authentication failed for 'https://gitlab.com/DerpFest/prebuilts_clang_host_linux-x-86.git/'
  error: Cannot fetch prebuilts_clang_host_linux-x-86 from https://gitlab.com/DerpFest/prebuilts_clang_host_linux-x-86

Signed-off-by: adnan-44 <mohd.adnan0405@gmail.com>